### PR TITLE
CI/CD - Limit ChatGPT API Key Usage

### DIFF
--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -52,7 +52,7 @@ jobs:
           echo "Any changes: $any_submission_changes"
           echo "any_submission_changes=$any_submission_changes" >> $GITHUB_OUTPUT
           
-          before_sha="${{ github.event.pull_request.base.sha }}"  # ! "${{ github.event.before }}"
+          before_sha="${{ github.event.before }}" #! "${{ github.event.pull_request.base.sha }}" 
           after_sha="${{ github.event.after }}"
           if ! git rev-parse --verify "$before_sha" >/dev/null || ! git rev-parse --verify "$after_sha" >/dev/null || [ -z "${{ github.event.before }}" ] || [ -z "${{ github.event.after }}" ]; then
             echo "One or both of the commit SHAs don't exist. Skipping git diff."


### PR DESCRIPTION
setting before sha to event before in github context to limit chatgpt api usage